### PR TITLE
ping1d: deprecate some outdated interfaces

### DIFF
--- a/src/definitions/ping1d.json
+++ b/src/definitions/ping1d.json
@@ -113,7 +113,8 @@
                         "type": "u16",
                         "description": "Firmware version minor number."
                     }
-                ]
+                ],
+                "deprecated": "true"
             },
             "device_id": {
                 "id": "1201",
@@ -251,7 +252,8 @@
                         "type": "u8",
                         "description": "The current operating mode of the device. 0: manual mode, 1: auto mode"
                     }
-                ]
+                ],
+                "deprecated": "true"
             },
             "distance_simple": {
                 "id": "1211",


### PR DESCRIPTION
The 'firmware version' is available under common messages, and are making it difficult to develop templated device apis because the common base class `firmware_version` members are shadowed by the ping1d `firmware_version` members.