### PR TITLE
definition: ping360: Add missing set prefix in set_device_id

### DIFF
--- a/src/definitions/ping360.json
+++ b/src/definitions/ping360.json
@@ -1,7 +1,7 @@
 {
     "messages": {
         "set": {
-            "device_id": {
+            "set_device_id": {
                 "id": 2000,
                 "description": "Change the device id",
                 "payload": [


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>