### PR TITLE
src: definitions: ping1d: improve `scan_length` description

### DIFF
--- a/src/definitions/ping1d.json
+++ b/src/definitions/ping1d.json
@@ -25,7 +25,7 @@
                     {
                         "name": "scan_length",
                         "type": "u32",
-                        "description": "The length of the scan range.",
+                        "description": "The total length of the scan range from the transducer.",
                         "units": "mm"
                     }
                 ]


### PR DESCRIPTION
Original description was ambiguous and made it seem like `scan_length` could be relative (from `scan_start`).

Caused an issue in [this forum post](https://discuss.bluerobotics.com/t/manual-mode-calibration/11441).