### PR TITLE
src: definitions: ping1d: improve `scan_length` description

### DIFF
--- a/src/definitions/ping1d.json
+++ b/src/definitions/ping1d.json
@@ -25,7 +25,7 @@
                     {
                         "name": "scan_length",
                         "type": "u32",
-                        "description": "The length of the scan range.",
+                        "description": "The length of the scan range. Minimum 1000.",
                         "units": "mm"
                     }
                 ]


### PR DESCRIPTION
Original description didn't specify the minimum length of 1000mm that's apparently implemented in the firmware.

Caused an issue in [this forum post](https://discuss.bluerobotics.com/t/manual-mode-calibration/11441).

Unsure whether the correct fix here is to update the description (as per this PR) or to update the firmware to allow smaller measurement ranges. I'm not certain why that limit is there at all - perhaps it was intended to be (`scan_start` + `scan_length` >= 1000mm) or something (maybe to avoid scanning too fast and damaging the transducer?), but the current limit of (`scan_length` >= 1000mm) seems like an unnecessary and arbitrary limitation to the device.

If there is reasoning for it it'd be good if we can provide that somewhere :-)
If the reasoning is on the 'transducer protection' front then that should probably be refactored in the firmware to be time-based anyway, since the current implementation is independent of `speed of sound`.