### PR TITLE
definitions: ping360: improve message descriptions

### DIFF
--- a/src/definitions/ping360.json
+++ b/src/definitions/ping360.json
@@ -37,18 +37,19 @@
                         "name": "angle",
                         "type": "u16",
                         "description": "Head angle",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "transmit_duration",
                         "type": "u16",
                         "description": "Acoustic transmission duration (1~1000 microseconds)",
-                        "units": "microsecond"
+                        "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)"
+                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
@@ -59,7 +60,8 @@
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)",
+                        "units": "samples"
                     },
                     {
                         "name": "data",
@@ -91,18 +93,19 @@
                         "name": "angle",
                         "type": "u16",
                         "description": "Head angle",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "transmit_duration",
                         "type": "u16",
                         "description": "Acoustic transmission duration (1~1000 microseconds)",
-                        "units": "microsecond"
+                        "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)"
+                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
@@ -114,30 +117,31 @@
                         "name": "start_angle",
                         "type": "u16",
                         "description": "Head angle to begin scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "stop_angle",
                         "type": "u16",
                         "description": "Head angle to end scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "num_steps",
                         "type": "u8",
                         "description": "Number of 0.9 degree motor steps between pings for auto scan (1~10 = 0.9~9.0 degrees)",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "delay",
                         "type": "u8",
                         "description": "An additional delay between successive transmit pulses (0~100 ms). This may be necessary for some programs to avoid collisions on the RS485 USRT.",
-                        "units": "millisecond"
+                        "units": "milliseconds"
                     },
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)",
+                        "units": "samples"
                     },
                     {
                         "name": "data",
@@ -187,18 +191,19 @@
                         "name": "angle",
                         "type": "u16",
                         "description": "Head angle",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "transmit_duration",
                         "type": "u16",
                         "description": "Acoustic transmission duration (1~1000 microseconds)",
-                        "units": "microsecond"
+                        "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)"
+                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
@@ -209,7 +214,8 @@
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)",
+                        "units": "samples"
                     },
                     {
                         "name": "transmit",
@@ -241,12 +247,13 @@
                         "name": "transmit_duration",
                         "type": "u16",
                         "description": "Acoustic transmission duration (1~1000 microseconds)",
-                        "units": "microsecond"
+                        "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)"
+                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
@@ -257,31 +264,32 @@
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)",
+                        "units": "samples"
                     },
                     {
                         "name": "start_angle",
                         "type": "u16",
                         "description": "Head angle to begin scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "stop_angle",
                         "type": "u16",
                         "description": "Head angle to end scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "num_steps",
                         "type": "u8",
                         "description": "Number of 0.9 degree motor steps between pings for auto scan (1~10 = 0.9~9.0 degrees)",
-                        "units": "gradian"
+                        "units": "gradians"
                     },
                     {
                         "name": "delay",
                         "type": "u8",
                         "description": "An additional delay between successive transmit pulses (0~100 ms). This may be necessary for some programs to avoid collisions on the RS485 USRT.",
-                        "units": "millisecond"
+                        "units": "milliseconds"
                     }
                 ]
             },

--- a/src/definitions/ping360.json
+++ b/src/definitions/ping360.json
@@ -42,20 +42,20 @@
                     {
                         "name": "transmit_duration",
                         "type": "u16",
-                        "description": "Acoustic transmission duration (1~1000 microseconds)",
+                        "description": "Acoustic transmission duration (1~1000 us)",
                         "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "description": "Time interval between individual signal intensity samples in 25 ns increments (80 to 40000 == 2 to 1000 us)",
                         "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
                         "type": "u16",
-                        "description": "Acoustic operating frequency. Frequency range is 500kHz to 1000kHz, however it is only practical to use say 650kHz to 850kHz due to the narrow bandwidth of the acoustic receiver.",
-                        "units": "kHz"
+                        "description": "Acoustic operating frequency (500~1000 kHz). It is only practical to use say 650 to 850 kHz due to the narrow bandwidth of the acoustic receiver.",
+                        "units": "kilohertz"
                     },
                     {
                         "name": "number_of_samples",
@@ -98,31 +98,31 @@
                     {
                         "name": "transmit_duration",
                         "type": "u16",
-                        "description": "Acoustic transmission duration (1~1000 microseconds)",
+                        "description": "Acoustic transmission duration (1~1000 us)",
                         "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "description": "Time interval between individual signal intensity samples in 25 ns increments (80 to 40000 == 2 to 1000 us)",
                         "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
                         "type": "u16",
-                        "description": "Acoustic operating frequency. Frequency range is 500kHz to 1000kHz, however it is only practical to use say 650kHz to 850kHz due to the narrow bandwidth of the acoustic receiver.",
-                        "units": "kHz"
+                        "description": "Acoustic operating frequency (500~1000 kHz). It is only practical to use say 650 to 850 kHz due to the narrow bandwidth of the acoustic receiver.",
+                        "units": "kilohertz"
                     },
                     {
                         "name": "start_angle",
                         "type": "u16",
-                        "description": "Head angle to begin scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
+                        "description": "Head angle to begin scan sector for autoscan (0~399 = 0~360 degrees).",
                         "units": "gradians"
                     },
                     {
                         "name": "stop_angle",
                         "type": "u16",
-                        "description": "Head angle to end scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
+                        "description": "Head angle to end scan sector for autoscan (0~399 = 0~360 degrees).",
                         "units": "gradians"
                     },
                     {
@@ -196,20 +196,20 @@
                     {
                         "name": "transmit_duration",
                         "type": "u16",
-                        "description": "Acoustic transmission duration (1~1000 microseconds)",
+                        "description": "Acoustic transmission duration (1~1000 us)",
                         "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "description": "Time interval between individual signal intensity samples in 25 ns increments (80 to 40000 == 2 to 1000 us)",
                         "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
                         "type": "u16",
-                        "description": "Acoustic operating frequency. Frequency range is 500kHz to 1000kHz, however it is only practical to use say 650kHz to 850kHz due to the narrow bandwidth of the acoustic receiver.",
-                        "units": "kHz"
+                        "description": "Acoustic operating frequency (500~1000 kHz). It is only practical to use say 650 to 850 kHz due to the narrow bandwidth of the acoustic receiver.",
+                        "units": "kilohertz"
                     },
                     {
                         "name": "number_of_samples",
@@ -246,20 +246,20 @@
                     {
                         "name": "transmit_duration",
                         "type": "u16",
-                        "description": "Acoustic transmission duration (1~1000 microseconds)",
+                        "description": "Acoustic transmission duration (1~1000 us)",
                         "units": "microseconds"
                     },
                     {
                         "name": "sample_period",
                         "type": "u16",
-                        "description": "Time interval between individual signal intensity samples in 25nsec increments (80 to 40000 == 2 microseconds to 1000 microseconds)",
+                        "description": "Time interval between individual signal intensity samples in 25 ns increments (80 to 40000 == 2 to 1000 us)",
                         "units": "eicosapenta-nanoseconds"
                     },
                     {
                         "name": "transmit_frequency",
                         "type": "u16",
-                        "description": "Acoustic operating frequency. Frequency range is 500kHz to 1000kHz, however it is only practical to use say 650kHz to 850kHz due to the narrow bandwidth of the acoustic receiver.",
-                        "units": "kHz"
+                        "description": "Acoustic operating frequency (500~1000 kHz). It is only practical to use say 650 to 850 kHz due to the narrow bandwidth of the acoustic receiver.",
+                        "units": "kilohertz"
                     },
                     {
                         "name": "number_of_samples",
@@ -270,13 +270,13 @@
                     {
                         "name": "start_angle",
                         "type": "u16",
-                        "description": "Head angle to begin scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
+                        "description": "Head angle to begin scan sector for autoscan (0~399 = 0~360 degrees).",
                         "units": "gradians"
                     },
                     {
                         "name": "stop_angle",
                         "type": "u16",
-                        "description": "Head angle to end scan sector for autoscan in gradians (0~399 = 0~360 degrees).",
+                        "description": "Head angle to end scan sector for autoscan (0~399 = 0~360 degrees).",
                         "units": "gradians"
                     },
                     {

--- a/src/definitions/ping360.json
+++ b/src/definitions/ping360.json
@@ -77,7 +77,7 @@
             },
             "auto_device_data": {
                 "id": 2301,
-                "description": "[NOT RELEASED] Extended version of *device_data* with *auto_transmit* information. The sensor emits this message when in *auto_transmit* mode.",
+                "description": "**[NOT RELEASED]** Extended version of `device_data` with `auto_transmit` information. The sensor emits this message when in `auto_transmit` mode.",
                 "payload": [
                     {
                         "name": "mode",
@@ -231,7 +231,7 @@
             },
             "auto_transmit": {
                 "id": 2602,
-                "description": "Extended *transducer* message with auto-scan function. The sonar will automatically scan the region between start_angle and end_angle and send auto_device_data messages as soon as new data is available. Send a line break to stop scanning (and also begin the autobaudrate procedure). Alternatively, a motor_off message may be sent (but retrys might be necessary on the half-duplex RS485 interface).",
+                "description": "**[NOT RELEASED]** Extended `transducer` message with auto-scan function. The sonar will automatically scan the region between `start_angle` and `end_angle` and send `auto_device_data` messages as soon as new data is available. Send a line break to stop scanning (and also begin the autobaudrate procedure). Alternatively, a `motor_off` message may be sent (but retries might be necessary on the half-duplex RS485 interface).",
                 "payload": [
                     {
                         "name": "mode",

--- a/src/definitions/ping360.json
+++ b/src/definitions/ping360.json
@@ -59,7 +59,7 @@
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
                     },
                     {
                         "name": "data",
@@ -137,7 +137,7 @@
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
                     },
                     {
                         "name": "data",
@@ -209,7 +209,7 @@
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
                     },
                     {
                         "name": "transmit",
@@ -257,7 +257,7 @@
                     {
                         "name": "number_of_samples",
                         "type": "u16",
-                        "description": "Number of samples per reflected signal"
+                        "description": "Number of samples per reflected signal (supported values: 200~1200)"
                     },
                     {
                         "name": "start_angle",

--- a/src/definitions/ping360.json
+++ b/src/definitions/ping360.json
@@ -175,7 +175,7 @@
             },
             "transducer": {
                 "id": 2601,
-                "description": "The transducer will apply the commanded settings. The sonar will reply with a `ping360_data` message. If the `transmit` field is 0, the sonar will not transmit after locating the transducer, and the `data` field in the `ping360_data` message reply will be empty. If the `transmit` field is 1, the sonar will make an acoustic transmission after locating the transducer, and the resulting data will be uploaded in the `data` field of the `ping360_data` message reply. To allow for the worst case response time the command timeout should be set to 4000 msec.",
+                "description": "The transducer will apply the commanded settings. The sonar will reply with a `device_data` message. If the `transmit` field is 0, the sonar will not transmit after locating the transducer, and the `data` field in the `device_data` message reply will be empty. If the `transmit` field is 1, the sonar will make an acoustic transmission after locating the transducer, and the resulting data will be uploaded in the `data` field of the `device_data` message reply. To allow for the worst case response time the command timeout should be set to 4000 msec.",
                 "payload": [
                     {
                         "name": "mode",


### PR DESCRIPTION
Determined by sending `set_number_of_samples` requests to a Ping360 device and seeing which values it accepted.

Ideally this would be defined for the device itself, rather than in a protocol specification (given a protocol could conceivably support multiple similar devices, which may have different valid values), but at the moment this seems to be the existing approach, and there currently isn't anywhere else the relevant valid ranges are specified.

If we wanted to change approach, the device product page may be a reasonable place to specify the valid values, but there's some information efficiency benefit to having the values available in the same place as the protocol specification. Doesn't really matter until another device tries to implement the same protocol and happens to have different valid values, so not a problem for now.

---

Would be nice if we could go one level more abstract to reduce redundancy, although that would slightly increase the project implementation complexity. Typing out four of the same message seems non-ideal and error-prone - would be better/nicer if we could re-use parameter definitions with some form of templating. Perhaps a job for another day, if at all.