### PR TITLE
Readme: remove Travis and Appveyor badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ping-protocol
 
-[![Travis Build Status](https://travis-ci.org/bluerobotics/ping-protocol.svg?branch=master)](https://travis-ci.org/bluerobotics/ping-protocol) [![Build status](https://ci.appveyor.com/api/projects/status/9wodlqle7wqvhiyn/branch/master?svg=true)](https://ci.appveyor.com/project/blueroboticsappveyor/ping-protocol/branch/master) [![Last Releases](https://img.shields.io/github/release/bluerobotics/ping-protocol.svg)](https://github.com/bluerobotics/ping-protocol/releases) [![Discuss](https://img.shields.io/badge/discuss-online-green.svg)](https://discuss.bluerobotics.com/)
+[![Last Releases](https://img.shields.io/github/release/bluerobotics/ping-protocol.svg)](https://github.com/bluerobotics/ping-protocol/releases) [![Discuss](https://img.shields.io/badge/discuss-online-green.svg)](https://discuss.bluerobotics.com/)
 
 <a href="https://bluerobotics.com">
 <img src="https://avatars2.githubusercontent.com/u/7120633?v=3&s=150" align="right" hspace="10" vspace="6">


### PR DESCRIPTION
they are broken, and we dont even use them anymore