### PR TITLE
Ping360: update for protocol `v1.1.0`

### DIFF
--- a/src/definitions/ping360.json
+++ b/src/definitions/ping360.json
@@ -77,7 +77,7 @@
             },
             "auto_device_data": {
                 "id": 2301,
-                "description": "**[NOT RELEASED]** Extended version of `device_data` with `auto_transmit` information. The sensor emits this message when in `auto_transmit` mode.",
+                "description": "**NEW (v1.1.0)** Extended version of `device_data` with `auto_transmit` information. The sensor emits this message when in `auto_transmit` mode.",
                 "payload": [
                     {
                         "name": "mode",
@@ -231,7 +231,7 @@
             },
             "auto_transmit": {
                 "id": 2602,
-                "description": "**[NOT RELEASED]** Extended `transducer` message with auto-scan function. The sonar will automatically scan the region between `start_angle` and `end_angle` and send `auto_device_data` messages as soon as new data is available. Send a line break to stop scanning (and also begin the autobaudrate procedure). Alternatively, a `motor_off` message may be sent (but retries might be necessary on the half-duplex RS485 interface).",
+                "description": "**NEW (v1.1.0)** Extended `transducer` message with auto-scan function. The sonar will automatically scan the region between `start_angle` and `end_angle` and send `auto_device_data` messages as soon as new data is available. Send a line break to stop scanning (and also begin the autobaudrate procedure). Alternatively, a `motor_off` message may be sent (but retries might be necessary on the half-duplex RS485 interface).",
                 "payload": [
                     {
                         "name": "mode",


### PR DESCRIPTION
Update docs for new auto-transmit messages.

We should probably make a new tag for `v1.1.0`, and we may also want to create a new `v1.0.0` tag with the auto-messages removed (since they weren't actually supported in that protocol version)