### PR TITLE
Fix OMNISCAN450_SET_SPEED_OF_SOUND id: 1002 -> 116

### DIFF
--- a/src/definitions/omniscan450.json
+++ b/src/definitions/omniscan450.json
@@ -17,7 +17,7 @@
         },
         "control": {
             "set_speed_of_sound": {
-                "id": 1002,
+                "id": 116,
                 "description": "Set the speed of sound.",
                 "payload": [
                     {


### PR DESCRIPTION
_This is my first PR on a open-source codebase. I used AI to navigate the process but have manually reviewed everything to the best of my knowledge._

## Problem
The OMNISCAN450 sonar protocol defines `set_speed_of_sound` message with ID 1002, 
but the device expects and sends message ID 116.
This can be confirmed here: https://docs.ceruleansonar.com/c/omniscan-450/application-programming-interface

This causes:
- Protocol mismatch when communicating with hardware
- SET_SPEED_OF_SOUND commands ignored by device (returns 'not-acknowledged')
- Speed of sound is not adjusted

## Root Cause
The definition in `src/definitions/omniscan450.json` has the wrong message ID.

## Solution
Changed `"set_speed_of_sound"` ID from 1002 to 116 in omniscan450.json.
This aligns the protocol definition with actual device behavior (https://docs.ceruleansonar.com/c/omniscan-450/application-programming-interface)

## How to Verify
1. Review the change in `src/definitions/omniscan450.json`
2. Confirm with Omniscan450 device specification documentation
3. Once merged, ping-python will regenerate `brping/definitions.py` 
   with `OMNISCAN450_SET_SPEED_OF_SOUND = 116`

## Related
- Affects: bluerobotics/ping-python (needs submodule update)
- Device: Cerulean Omniscan450 FS sonar
- Severity: High (breaks communication with device)