### PR TITLE
Fix OmniScan 450 Set Speed of Sound Packet ID

### DIFF
--- a/src/definitions/omniscan450.json
+++ b/src/definitions/omniscan450.json
@@ -17,7 +17,7 @@
         },
         "control": {
             "set_speed_of_sound": {
-                "id": 1002,
+                "id": 116,
                 "description": "Set the speed of sound.",
                 "payload": [
                     {


### PR DESCRIPTION
## Summary

Fixes the packet ID for the OmniScan 450 Set Speed of Sound message.

## Changes

- Corrected the packet ID for `set_speed_of_sound`, 1002->116
- Updated the protocol definition so generated documentation/code use the correct packet ID

## Notes

This PR is intentionally limited to the OmniScan 450 speed-of-sound packet ID fix.